### PR TITLE
fix: dont use nvim win cursor apis

### DIFF
--- a/lua/conflict-marker/init.lua
+++ b/lua/conflict-marker/init.lua
@@ -47,8 +47,8 @@ function Conflict:with_cursor_in_conflict_region(fn)
     local extmarks = vim.api.nvim_buf_get_extmarks(
         self.bufnr,
         NS_HL,
-        { cursor[1] - 1, 0 },
-        { cursor[1] - 1, 0 },
+        { cursor[2] - 1, 0 },
+        { cursor[2] - 1, 0 },
         { overlap = true }
     )
 


### PR DESCRIPTION
## Problem

`vim.api.nvim_win_set/get_cursor` scrolls the window

## Solution

Use `vim.fn.setpos/getpos/cursor` which doesn't seem to do that
